### PR TITLE
fix: add client_name and client_version to ndt7 locate url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:4.0.2"
+        classpath "com.android.tools.build:gradle:4.1.1"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.1")
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 27 11:08:37 CDT 2020
+#Wed Nov 18 11:32:52 CST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip

--- a/libndt7/build.gradle
+++ b/libndt7/build.gradle
@@ -6,14 +6,18 @@ apply plugin: "org.jlleitschuh.gradle.ktlint"
 
 android {
 
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 7
         versionName "0.2.0"
         consumerProguardFiles "proguard-rules.pro"
+
+        // AGP 4.1+ doesn't add VERSION_NAME or VERSION_CODE to aars by default anymore
+        def version =  '\"' + versionName.toString() +'\"'
+        buildConfigField 'String', 'NDT7_ANDROID_VERSION_NAME', version
 
         compileOptions {
             sourceCompatibility 1.8

--- a/libndt7/build.gradle
+++ b/libndt7/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionCode 7
-        versionName "0.2.0"
+        versionCode 8
+        versionName "0.2.1"
         consumerProguardFiles "proguard-rules.pro"
 
         // AGP 4.1+ doesn't add VERSION_NAME or VERSION_CODE to aars by default anymore

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/NDTTest.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/NDTTest.kt
@@ -102,7 +102,7 @@ abstract class NDTTest(private var httpClient: OkHttpClient? = null) : DataPubli
     }
 
     private fun getHostname(): Call? {
-        val locateServerUrl = "https://locate.measurementlab.net/v2/nearest/ndt/ndt7"
+        val locateServerUrl = "https://locate.measurementlab.net/v2/nearest/ndt/ndt7?client_name=ndt7-android&client_version=${BuildConfig.NDT7_ANDROID_VERSION_NAME}"
         val request = Request.Builder()
             .method("GET", null)
             .url(locateServerUrl)

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/SocketFactory.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/SocketFactory.kt
@@ -16,7 +16,6 @@ internal object SocketFactory {
         val request = Request.Builder()
             .url(url)
             .addHeader("Sec-WebSocket-Protocol", "net.measurementlab.ndt.v7")
-            .addHeader("User-Agent", "ndt7-kotlin-client ${BuildConfig.VERSION_NAME}")
             .build()
 
         return httpClient?.newWebSocket(request, listener) ?: throw Error("socket unable to be created")


### PR DESCRIPTION
- Adds the client_name and client_version to the ndt7 locate url. This change was discussed in the previous PR and was put on hold due to breaking changes in AGP 4.1. Turns out the fix wasn't that complicated, we can just inject the version name into the BuildConfig manually 

- Upgraded to Android 11 and AGP 4.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-android/11)
<!-- Reviewable:end -->
