### PR TITLE
Remove unused import in SocketFactory.kt

### DIFF
--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/SocketFactory.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/SocketFactory.kt
@@ -1,7 +1,6 @@
 @file:JvmName("SocketFactory")
 package net.measurementlab.ndt7.android.utils
 
-import net.measurementlab.ndt7.android.BuildConfig
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.WebSocket


### PR DESCRIPTION
This unused import makes the build with `./gradlew build` fail:
```
> Task :libndt7:ktlintMainSourceSetCheck
/home/roberto/git/ndt7-client-android/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/SocketFactory.kt:4:1: Unused import
"plain" report written to /home/roberto/git/ndt7-client-android/libndt7/build/reports/ktlint/ktlintMainSourceSetCheck/ktlintMainSourceSetCheck.txt

> Task :libndt7:ktlintMainSourceSetCheck FAILED
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-android/13)
<!-- Reviewable:end -->
