### PR TITLE
Set "numBytes" attribute from the ClientResponse class to Long instead of Double

### DIFF
--- a/libndt7/src/androidTest/java/net/measurementlab/ndt7/androidTest/PayloadTransformerTest.kt
+++ b/libndt7/src/androidTest/java/net/measurementlab/ndt7/androidTest/PayloadTransformerTest.kt
@@ -12,7 +12,7 @@ class PayloadTransformerTest {
     fun test_dynamic_tuning_doesnt_change_if_max_size() {
         val oldBytes = ByteString.of(*ByteArray(NDT7Constants.MAX_MESSAGE_SIZE))/* (1<<13) */
 
-        val newBytes = PayloadTransformer.performDynamicTuning(oldBytes, 0, 0.0)
+        val newBytes = PayloadTransformer.performDynamicTuning(oldBytes, 0, 0)
 
         Assert.assertTrue(newBytes.size == oldBytes.size)
     }
@@ -21,7 +21,7 @@ class PayloadTransformerTest {
     fun test_dynamic_tuning_doesnt_change_if_queue_is_saturated() {
         val oldBytes = ByteString.of(*ByteArray(1000))/* (1<<13) */
 
-        val newBytes = PayloadTransformer.performDynamicTuning(oldBytes, 0, 16000.0)
+        val newBytes = PayloadTransformer.performDynamicTuning(oldBytes, 0, 16000)
 
         Assert.assertTrue(newBytes.size == oldBytes.size)
     }
@@ -29,7 +29,7 @@ class PayloadTransformerTest {
     fun test_dynamic_tuning_will_double() {
         val oldBytes = ByteString.of(*ByteArray(10))/* (1<<13) */
 
-        val newBytes = PayloadTransformer.performDynamicTuning(oldBytes, 10000, 16000.0)
+        val newBytes = PayloadTransformer.performDynamicTuning(oldBytes, 10000, 16000)
 
         Assert.assertTrue(newBytes.size == oldBytes.size * 2)
     }

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/Downloader.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/Downloader.kt
@@ -25,7 +25,7 @@ class Downloader(
 
     private var startTime: Long = 0
     private var previous: Long = 0
-    private var numBytes = 0.0
+    private var numBytes: Long = 0
     private val gson = Gson()
     private var webSocket: WebSocket? = null
 
@@ -34,7 +34,7 @@ class Downloader(
     }
 
     override fun onMessage(webSocket: WebSocket, text: String) {
-        numBytes += text.length.toDouble()
+        numBytes += text.length.toLong()
         tryToUpdateClient()
 
         try {
@@ -46,7 +46,7 @@ class Downloader(
     }
 
     override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
-        numBytes += bytes.size.toDouble()
+        numBytes += bytes.size.toLong()
         tryToUpdateClient()
     }
 

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/Uploader.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/Uploader.kt
@@ -28,7 +28,7 @@ class Uploader(
 
     private var startTime: Long = 0
     private var previous: Long = 0
-    private var totalBytesSent = 0.0
+    private var totalBytesSent: Long = 0
     private val gson = Gson()
 
     override fun onMessage(webSocket: WebSocket, text: String) {
@@ -95,7 +95,7 @@ class Uploader(
         tryToUpdateUpload(totalBytesSent, ws)
     }
 
-    private fun tryToUpdateUpload(total: Double, ws: WebSocket) {
+    private fun tryToUpdateUpload(total: Long, ws: WebSocket) {
         val now = currentTimeInMicroseconds()
 
         // if we haven't sent an update in 250ms, lets send one

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/models/ClientResponse.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/models/ClientResponse.kt
@@ -10,5 +10,5 @@ data class ClientResponse(
 
 data class AppInfo(
     @SerializedName("ElapsedTime") val elapsedTime: Long,
-    @SerializedName("NumBytes") val numBytes: Double
+    @SerializedName("NumBytes") val numBytes: Long
 )

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/DataConverter.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/DataConverter.kt
@@ -7,7 +7,7 @@ import net.measurementlab.ndt7.android.models.ClientResponse
 
 object DataConverter {
 
-    @JvmStatic fun generateResponse(startTime: Long, numBytes: Double, testType: NDTTest.TestType): ClientResponse {
+    @JvmStatic fun generateResponse(startTime: Long, numBytes: Long, testType: NDTTest.TestType): ClientResponse {
         return ClientResponse(AppInfo(currentTimeInMicroseconds() - startTime, numBytes), test = testType.value)
     }
 

--- a/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/PayloadTransformer.kt
+++ b/libndt7/src/main/java/net/measurementlab/ndt7/android/utils/PayloadTransformer.kt
@@ -6,7 +6,7 @@ internal object PayloadTransformer {
 
     // this is gonna let higher speed clients saturate their pipes better
     // it will gradually increase the size of data if the websocket queue isn't filling up
-    fun performDynamicTuning(data: ByteString, queueSize: Long, bytesEnqueued: Double): ByteString {
+    fun performDynamicTuning(data: ByteString, queueSize: Long, bytesEnqueued: Long): ByteString {
         val totalBytesTransmitted = bytesEnqueued - queueSize
 
         return if (data.size * 2 < NDT7Constants.MAX_MESSAGE_SIZE && data.size < totalBytesTransmitted / 16) {


### PR DESCRIPTION
Sets the numBytes attribute of the ClientResponse class to be a Long. 

Being treated as a Double was causing incompatibility problems with other NDT7 clients and the server. In addition, in the other developed clients, as well as in the server, this attribute is treated as an int64.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt7-client-android/18)
<!-- Reviewable:end -->
